### PR TITLE
Add ability to query Debian sources repository and simplify downloading of binary packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,13 @@
 Package: debbie 
 Title: Retrieve and Install Debian Binary Versions of R Packages
-Version: 0.0.0.9000
+Version: 0.1
 Authors@R: person("Ryan Patrick", "Kyle", email = "ryan@plot.ly", role = c("aut", "cre"))
-Description: This package is intended for users of R on Debian or Ubuntu hosts who would like to leverage binary versions of R packages in Debian package repositories, but who are either unable or too lazy to install them the typical way via apt.  
+Description: This package is intended for users of R on Debian or Ubuntu hosts who would like to leverage binary versions of R packages in Debian package repositories, but who are either unable or choose not to install them the typical way via apt.
 Depends: R (>= 3.0.2)
-Imports: curl, utils, callr, remotes 
+Imports: curl, utils, callr, remotes, httr, jsonlite
 License: MIT 
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
+URL: https://github.com/rpkyle/debbie
+BugReports: https://github.com/rpkyle/debbie/issues


### PR DESCRIPTION
This PR proposes to implement several changes to the `debbie` API to simplify the download process:
- instead of passing the URL to a Debian package, users may now only pass the package name to `install_deb`, which handles constructing the URL
- there is a Debian API for retrieving source package information, but not for binary packages; `debbie` currently attempts to work around this by querying the sources API and constructing the URLs to packages manually
- given the number of assumptions the package currently makes, several internal checks are now performed throughout the process, and `install_deb` will now throw simple errors if the checks fail
- a few additional arguments to `install_deb` now allow more user control over reporting
- `tempdir()` is now the default download directory, and "cleaning" (deleting) the package directories post-download is no longer supported (since `tempdir()` should link to a path that is cleaned post-session)
- dependencies on `httr`, `jsonlite` have been specified in the `Suggests` field of the `DESCRIPTION`
- version bumped to `0.1.0`

Unit tests will be added to the package soon.