### PR TITLE
Initial attempt at resolving dependencies and installing from binary packages when available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.1
 Authors@R: person("Ryan Patrick", "Kyle", email = "ryan@plot.ly", role = c("aut", "cre"))
 Description: This package is intended for users of R on Debian or Ubuntu hosts who would like to leverage binary versions of R packages in Debian package repositories, but who are either unable or choose not to install them the typical way via apt.
 Depends: R (>= 3.0.2)
-Imports: curl, utils, callr, remotes, httr, jsonlite
+Imports: curl, utils, callr, remotes, httr, jsonlite, miniCRAN
 License: MIT 
 Encoding: UTF-8
 LazyData: true

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -154,8 +154,10 @@ install_deb <- function (package = NULL,
     comma_separated_deps <- paste0(unformatted_deps, collapse = ", ")
     list_of_deps <- strsplit(comma_separated_deps, ", ")
     list_of_deps <- lapply(list_of_deps, function(x) gsub(" *\\([^()]*\\)", "", x)) # ignore version for now
-    deps_to_install <- lapply(list_of_deps, function(x) x[!x %in% installed.packages()[,"Package"]])
-    if (length(unlist(deps_to_install)) != 0) {
+    deps_to_install <- unlist(list_of_deps)
+    # limit to those packages not currently installed
+    deps_to_install <- deps_to_install[!deps_to_install %in% installed.packages()[,"Package"]]
+    if (length(deps_to_install) != 0) {
       message(sprintf("debbie is now attempting to install precompiled packages %s for %s from the Debian repository ...", 
                       paste0(unlist(deps_to_install), collapse = ", "),
                       package_name))

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -120,7 +120,7 @@ install_deb <- function (package = NULL,
     if (pkg_status == FALSE && fallback == FALSE) {
       stop(sprintf("the package '%s' was not found; the response returned was %s.", package, result$error))
     } else if (pkg_status == FALSE && fallback == TRUE) {
-      install.packages(package, repos = cran_mirror)
+      return(install.packages(package, repos = cran_mirror))
     } else {
       # ensure that release is available
       indexes <- vapply(result$versions$suites, function(x) any(release %in% x), logical(1))

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -195,7 +195,7 @@ install_deb <- function (package = NULL,
                                 function(x) 
                                   debPkgAvailable(x, 
                                                   deb_mirror, 
-                                                  sources_url),
+                                                  sources_url)[[1]],
                                                   logical(1)
                                 )
           

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -97,7 +97,7 @@ install_deb <- function (package = NULL,
     if ("error" %in% names(result) && fallback == FALSE) {
       stop(sprintf("the package '%s' was not found; the response returned was %s.", package, result$error))
     } else if ("error" %in% names(result) && fallback == TRUE) {
-      install.packages(package, repos = cran_mirror, upgrade = upgrade)
+      install.packages(package, repos = cran_mirror)
     } else {
       # ensure that release is available
       indexes <- vapply(result$versions$suites, function(x) any(release %in% x), logical(1))

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -145,7 +145,7 @@ install_deb <- function (package = NULL,
   if (!dir.exists(package_path))
     stop(sprintf("the inferred package path is invalid; check to see whether the Debian package includes the subdirectory 'usr/lib/R/site-library/%s'.", actual_path))
 
-  path_to_description <- file.path(actual_path, "DESCRIPTION")
+  path_to_description <- file.path(package_path, "DESCRIPTION")
   raw_deps <- read.dcf(path_to_description, fields = c("Depends", "Imports"))
   pruned_deps <- gsub(",* *R \\([^()]*\\),* *", "", raw_deps)
   

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -162,18 +162,19 @@ install_deb <- function (package = NULL,
       invisible(lapply(deps_to_install, 
                        function(x) {
                          install_deb(
-                         package = x,
-                         mirror = mirror,
-                         sources_url = sources_url,
-                         release = release,
-                         download_path = download_path,
-                         opts = opts,
-                         echo = echo,
-                         show = show,
-                         fail_on_status = fail_on_status,
-                         use_binary = TRUE,
-                         recursive = FALSE)
-                       }))
+                           package = pkg_name,
+                           mirror = mirror,
+                           sources_url = sources_url,
+                           release = release,
+                           download_path = download_path,
+                           opts = opts,
+                           echo = echo,
+                           show = show,
+                           fail_on_status = fail_on_status,
+                           use_binary = TRUE,
+                           recursive = FALSE)
+                       }
+                       ))
     } else if (use_binary == FALSE) {
       remotes::install_deps(pkgdir = package_path, build = FALSE, upgrade = upgrade, ...)
     }

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -160,18 +160,20 @@ install_deb <- function (package = NULL,
                       paste0(unlist(deps_to_install), collapse = ", "),
                       package_name))
       invisible(lapply(deps_to_install, 
-                       install_deb,
-                       package = pkg_name,
-                       mirror = mirror,
-                       sources_url = sources_url,
-                       release = release,
-                       download_path = download_path,
-                       opts = opts,
-                       echo = echo,
-                       show = show,
-                       fail_on_status = fail_on_status,
-                       use_binary = TRUE,
-                       recursive = FALSE))
+                       function(x) {
+                         install_deb(
+                         package = x,
+                         mirror = mirror,
+                         sources_url = sources_url,
+                         release = release,
+                         download_path = download_path,
+                         opts = opts,
+                         echo = echo,
+                         show = show,
+                         fail_on_status = fail_on_status,
+                         use_binary = TRUE,
+                         recursive = FALSE)
+                       }
     } else if (use_binary == FALSE) {
       remotes::install_deps(pkgdir = package_path, build = FALSE, upgrade = upgrade, ...)
     }

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -175,7 +175,7 @@ install_deb <- function (package = NULL,
         stop(sprintf("the inferred package path is invalid; check to see whether the Debian package includes the subdirectory 'usr/lib/R/site-library/%s'.", actual_path))
       
       path_to_description <- file.path(package_path, "DESCRIPTION")
-      raw_deps <- read.dcf(path_to_description, fields = c("Depends", "Imports"))
+      raw_deps <- suppressMessages(read.dcf(path_to_description, fields = c("Depends", "Imports")))
       pruned_deps <- gsub(",* *R \\([^()]*\\),* *", "", raw_deps)
       
       if (recursive == TRUE && use_binary == TRUE && !all(pruned_deps == "")) {

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -2,26 +2,26 @@
 #'
 #' This function attempts to download an R package compiled for
 #' Debian (which may work on hosts running Ubuntu also) using
-#' curl to the directory specified in `path`.
+#' curl to the directory specified in \code{path}.
 #' @param url A character string which represents a valid URL to an R package.
-#' @param path A character string describing the path where the package should be downloaded. Defaults to /tmp.
+#' @param path A character string describing the path where the package should be downloaded. Defaults to \code{tempdir()}.
 #' @keywords Debian download binary package 
 #' @export
-retrievePackage <- function(url, path="/tmp") {
+retrievePackage <- function(url, path=tempdir()) {
   package_archive <- file.path(path, basename(url))
   curl::curl_download(url, destfile=package_archive)
 }
 
 #' Extract a Debian archive containing an R package binary
 #'
-#' This function uses `untar` to extract the R package from within a Debian
+#' This function uses \code{untar} to extract the R package from within a Debian
 #' archive.
 #' @param pkg_path A character string describing the location of the compressed package.
 #' @param pkg_file A character string describing the filename of the Debian package.
 #' @param dest_path A character string describing the intended destination directory of the package.
 #' @keywords extract untar Debian binary 
 #' @export
-unpackPackage <- function(pkg_path, pkg_file, dest_path) {
+unpackPackage <- function(pkg_path = tempdir(), pkg_file, dest_path = tempdir()) {
   if (Sys.which("ar") == "")
     stop("the ar command is required to unpack the Debian package binaries, and was not found. Please ensure ar is available and in your current path.")
   
@@ -50,14 +50,14 @@ unpackPackage <- function(pkg_path, pkg_file, dest_path) {
 #' @param pkg_ver A character string describing a particular version of an R package, for which a search will be performed. 
 #' @param mirror A character string which represents a valid URL to a Debian package mirror's R package tree. Default is to use http://deb.debian.org/debian/pool/main/r.
 #' @param sources_url A character string which represents a valid URL to a Debian sources API. Default is https://sources.debian.org/api/src.
-#' @param release A character string describing the desired Debian release code name, default is `sid`.
-#' @param pkg_path A character string describing the intended destination directory of the package when downloaded. Default is the session temporary directory given by `tempdir()`.
+#' @param release A character string describing the desired Debian release code name, default is \code{sid}.
+#' @param pkg_path A character string describing the intended destination directory of the package when downloaded. Default is the session temporary directory given by \code{tempdir()}.
 #' @param clean Logical. A Boolean flag indicating whether the non-package directories extracted from the archive should be deleted.
-#' @param opts A vector of character strings containing command line arguments for `INSTALL`, used when installing the downloaded package. Default is `--no-docs`, `--no-multiarch`, `--no-demo`.
-#' @param echo Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the complete command should be echoed to the R console.
-#' @param show Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the standard output of the `INSTALL` command run by `callr::rcmd` should be displayed while the process is running.
-#' @param fail_on_status Logical. A Boolean flag passed to `callr::rcmd` which controls whether an error should be thrown if the underlying process terminates with a status code other than 0. Default is `TRUE`.
-#' @param ... Arguments to be passed on to `remotees::install_deps`.
+#' @param opts A vector of character strings containing command line arguments for \code{INSTALL}, used when installing the downloaded package. Default is \code{--no-docs}, \code{--no-multiarch}, \code{--no-demo}.
+#' @param echo Logical. A Boolean flag passed to \code{callr::rcmd} which indicates whether the complete command should be echoed to the R console.
+#' @param show Logical. A Boolean flag passed to \code{callr::rcmd} which indicates whether the standard output of the \code{INSTALL} command run by \code{callr::rcmd} should be displayed while the process is running.
+#' @param fail_on_status Logical. A Boolean flag passed to \code{callr::rcmd} which controls whether an error should be thrown if the underlying process terminates with a status code other than 0. Default is \code{TRUE}.
+#' @param ... Arguments to be passed on to \code{remotes::install_deps}.
 #' @keywords Debian binary install packages 
 #' @export
 install_deb <- function (package = NULL, 

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -167,11 +167,14 @@ install_deb <- function (package = NULL,
       # try to protect ourselves from case sensitivity; some
       # Debian packages store their assets in a subfolder whose
       # case does not match the package name; this is a workaround
-      path_to_assets <- file.path(download_path, "usr/lib/R/site-library")
+      subdirs <- tolower(list.files(file.path(download_path, "usr/lib/R/site-library")))
+      if (tolower(package_name) %in% subdirs)
+        path_to_assets <- file.path(download_path, "usr/lib/R/site-library")
+      else
+        path_to_assets <- file.path(download_path, "usr/lib/R/library")
+      
       actual_path <- list.files(path_to_assets)[(tolower(package_name) == tolower(list.files(path_to_assets)))]
       package_path <- file.path(path_to_assets, actual_path)
-      
-      browser()
       
       if (!dir.exists(package_path))
         stop(sprintf("the inferred package path is invalid; check to see whether the Debian package includes the subdirectory 'usr/lib/R/site-library/%s'.", actual_path))

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -194,7 +194,7 @@ install_deb <- function (package = NULL,
           # recursively find all necessary dependencies        
           deps_to_install <- miniCRAN::pkgDep(deps_to_install, suggests=FALSE)
           
-          deps_to_install <- vapply(deps_to_install, 
+          available <- vapply(deps_to_install, 
                                 function(x) 
                                   debPkgAvailable(x, 
                                                   deb_mirror, 
@@ -202,20 +202,20 @@ install_deb <- function (package = NULL,
                                                   logical(1)
                                 )
           
-          if (any(deps_to_install == TRUE)) 
+          if (any(available == TRUE)) 
             message(sprintf("debbie is now attempting to install precompiled packages %s for %s from the Debian repository ...", 
-                            paste0(names(deps_to_install[deps_to_install == TRUE]), collapse = ", "),
+                            paste0(deps_to_install[available], collapse = ", "),
                             package_name))
           
-          if (any(deps_to_install == FALSE))
+          if (any(available == FALSE))
             message(sprintf("debbie will also install source packages %s for %s from CRAN (not currently available as binaries)...", 
-                            paste0(names(deps_to_install[deps_to_install == FALSE]), collapse = ", "),
+                            paste0(deps_to_install[!available], collapse = ", "),
                             package_name))
           
           # try to install binary package versions first
           sorted_deps <- sort(deps_to_install, decreasing=TRUE)
                     
-          invisible(lapply(names(sorted_deps), 
+          invisible(lapply(c(deps_to_install[available], deps_to_install[!available]), 
                            function(x) {
                              install_deb(
                                package = x,

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -120,7 +120,7 @@ install_deb <- function (package = NULL,
     if (pkg_status == FALSE && fallback == FALSE) {
       stop(sprintf("the package '%s' was not found; the response returned was %s.", package, result$error))
     } else if (pkg_status == FALSE && fallback == TRUE) {
-      return(install.packages(package, repos = cran_mirror))
+      install.packages(package, repos = cran_mirror)
     } else {
       # ensure that release is available
       indexes <- vapply(result$versions$suites, function(x) any(release %in% x), logical(1))
@@ -170,6 +170,8 @@ install_deb <- function (package = NULL,
       path_to_assets <- file.path(download_path, "usr/lib/R/site-library")
       actual_path <- list.files(path_to_assets)[(tolower(package_name) == tolower(list.files(path_to_assets)))]
       package_path <- file.path(path_to_assets, actual_path)
+      
+      browser()
       
       if (!dir.exists(package_path))
         stop(sprintf("the inferred package path is invalid; check to see whether the Debian package includes the subdirectory 'usr/lib/R/site-library/%s'.", actual_path))

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -162,7 +162,7 @@ install_deb <- function (package = NULL,
       invisible(lapply(deps_to_install, 
                        function(x) {
                          install_deb(
-                           package = pkg_name,
+                           package = x,
                            mirror = mirror,
                            sources_url = sources_url,
                            release = release,

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -173,7 +173,7 @@ install_deb <- function (package = NULL,
                          fail_on_status = fail_on_status,
                          use_binary = TRUE,
                          recursive = FALSE)
-                       }
+                       }))
     } else if (use_binary == FALSE) {
       remotes::install_deps(pkgdir = package_path, build = FALSE, upgrade = upgrade, ...)
     }

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -82,14 +82,14 @@ install_deb <- function (package = NULL,
                          ...) 
 {
   if (!is.null(package)) {
-    if (httr::http_error(mirror))
+    if (httr::http_error(deb_mirror))
       stop("the specified Debian mirror URL does not exist or is unavailable. Please ensure that the URL describes the path to a valid Debian R package tree.")
     
     # remove r-cran from package name if present
     package <- gsub("r-cran-", "", package)
     
     # remove trailing slash(es) from URLs if present
-    mirror <- gsub("/+$", "", mirror)
+    deb_mirror <- gsub("/+$", "", deb_mirror)
     sources_url <- gsub("/+$", "", sources_url)
     
     result <- jsonlite::fromJSON(sprintf("%s/r-cran-%s/", sources_url, tolower(package)))
@@ -112,7 +112,7 @@ install_deb <- function (package = NULL,
           stop(sprintf("no matches found for release '%s' and version '%s' of package '%s'.", release, pkg_ver, package))
       }
       
-      base_url <- sprintf("%s/r-cran-%s/", mirror, tolower(package))
+      base_url <- sprintf("%s/r-cran-%s/", deb_mirror, tolower(package))
       filename <- sprintf("r-cran-%s_%s_amd64.deb", tolower(package), pkg_ver, ".deb")
       url <- sprintf("%s%s", base_url, filename)
       

--- a/R/debbie.R
+++ b/R/debbie.R
@@ -84,7 +84,7 @@ install_deb <- function (package = NULL,
   mirror <- gsub("/+$", "", mirror)
   sources_url <- gsub("/+$", "", sources_url)
   
-  result <- jsonlite::fromJSON(sprintf("%s/r-cran-%s/", sources_url, package))
+  result <- jsonlite::fromJSON(sprintf("%s/r-cran-%s/", sources_url, tolower(package)))
   
   if ("error" %in% names(result))
     stop(sprintf("the package '%s' was not found; the response returned was %s.", package, result$error))
@@ -102,8 +102,8 @@ install_deb <- function (package = NULL,
       stop(sprintf("no matches found for release '%s' and version '%s' of package '%s'.", release, pkg_ver, package))
   }
   
-  base_url <- sprintf("%s/r-cran-%s/", mirror, package)
-  filename <- sprintf("r-cran-%s_%s_amd64.deb", package, pkg_ver, ".deb")
+  base_url <- sprintf("%s/r-cran-%s/", mirror, tolower(package))
+  filename <- sprintf("r-cran-%s_%s_amd64.deb", tolower(package), pkg_ver, ".deb")
   url <- sprintf("%s%s", base_url, filename)
   
   if (!httr::http_error(url))
@@ -111,7 +111,7 @@ install_deb <- function (package = NULL,
   else {
     url <- sprintf("%s%s", 
                    base_url, 
-                   sprintf("r-cran-%s_%s_all.deb", package, pkg_ver, ".deb"))
+                   sprintf("r-cran-%s_%s_all.deb", tolower(package), pkg_ver, ".deb"))
     if (!httr::http_error(url))
       retrievePackage(url, download_path)
     else {

--- a/man/debbie-package.Rd
+++ b/man/debbie-package.Rd
@@ -8,6 +8,14 @@
 \description{
 Coming soon
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/rpkyle/debbie}
+  \item Report bugs at \url{https://github.com/rpkyle/debbie/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Ryan Patrick Kyle \email{ryan@plot.ly}
 

--- a/man/install_deb.Rd
+++ b/man/install_deb.Rd
@@ -4,19 +4,37 @@
 \alias{install_deb}
 \title{Install an R package from the Debian Package Repository}
 \usage{
-install_deb(package = NULL, url = NULL, path = "/tmp",
-  clean = TRUE, ...)
+install_deb(package = NULL, pkg_ver = NULL,
+  mirror = "http://deb.debian.org/debian/pool/main/r",
+  sources_url = "https://sources.debian.org/api/src", release = "sid",
+  download_path = tempdir(), clean = FALSE, opts = c("--no-docs",
+  "--no-multiarch", "--no-demo"), echo = FALSE, show = TRUE,
+  fail_on_status = TRUE, ...)
 }
 \arguments{
 \item{package}{A character string describing an R package, for which a search of the Debian package repository will be performed.}
 
-\item{url}{A character string which represents a valid URL to an R package.`}
+\item{pkg_ver}{A character string describing a particular version of an R package, for which a search will be performed.}
 
-\item{path}{A character string describing the intended destination directory of the package.}
+\item{mirror}{A character string which represents a valid URL to a Debian package mirror's R package tree. Default is to use http://deb.debian.org/debian/pool/main/r.}
+
+\item{sources_url}{A character string which represents a valid URL to a Debian sources API. Default is https://sources.debian.org/api/src.}
+
+\item{release}{A character string describing the desired Debian release code name, default is `sid`.}
 
 \item{clean}{Logical. A Boolean flag indicating whether the non-package directories extracted from the archive should be deleted.}
 
-\item{...}{Arguments to be passed on to `install.packages`.}
+\item{opts}{A vector of character strings containing command line arguments for `INSTALL`, used when installing the downloaded package. Default is `--no-docs`, `--no-multiarch`, `--no-demo`.}
+
+\item{echo}{Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the complete command should be echoed to the R console.}
+
+\item{show}{Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the standard output of the `INSTALL` command run by `callr::rcmd` should be displayed while the process is running.}
+
+\item{fail_on_status}{Logical. A Boolean flag passed to `callr::rcmd` which controls whether an error should be thrown if the underlying process terminates with a status code other than 0. Default is `TRUE`.}
+
+\item{...}{Arguments to be passed on to `remotees::install_deps`.}
+
+\item{pkg_path}{A character string describing the intended destination directory of the package when downloaded. Default is the session temporary directory given by `tempdir()`.}
 }
 \description{
 This function attempts to retrieve a Debian binary package corresponding

--- a/man/install_deb.Rd
+++ b/man/install_deb.Rd
@@ -20,21 +20,21 @@ install_deb(package = NULL, pkg_ver = NULL,
 
 \item{sources_url}{A character string which represents a valid URL to a Debian sources API. Default is https://sources.debian.org/api/src.}
 
-\item{release}{A character string describing the desired Debian release code name, default is `sid`.}
+\item{release}{A character string describing the desired Debian release code name, default is \code{sid}.}
 
 \item{clean}{Logical. A Boolean flag indicating whether the non-package directories extracted from the archive should be deleted.}
 
-\item{opts}{A vector of character strings containing command line arguments for `INSTALL`, used when installing the downloaded package. Default is `--no-docs`, `--no-multiarch`, `--no-demo`.}
+\item{opts}{A vector of character strings containing command line arguments for \code{INSTALL}, used when installing the downloaded package. Default is \code{--no-docs}, \code{--no-multiarch}, \code{--no-demo}.}
 
-\item{echo}{Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the complete command should be echoed to the R console.}
+\item{echo}{Logical. A Boolean flag passed to \code{callr::rcmd} which indicates whether the complete command should be echoed to the R console.}
 
-\item{show}{Logical. A Boolean flag passed to `callr::rcmd` which indicates whether the standard output of the `INSTALL` command run by `callr::rcmd` should be displayed while the process is running.}
+\item{show}{Logical. A Boolean flag passed to \code{callr::rcmd} which indicates whether the standard output of the \code{INSTALL} command run by \code{callr::rcmd} should be displayed while the process is running.}
 
-\item{fail_on_status}{Logical. A Boolean flag passed to `callr::rcmd` which controls whether an error should be thrown if the underlying process terminates with a status code other than 0. Default is `TRUE`.}
+\item{fail_on_status}{Logical. A Boolean flag passed to \code{callr::rcmd} which controls whether an error should be thrown if the underlying process terminates with a status code other than 0. Default is \code{TRUE}.}
 
-\item{...}{Arguments to be passed on to `remotees::install_deps`.}
+\item{...}{Arguments to be passed on to \code{remotes::install_deps}.}
 
-\item{pkg_path}{A character string describing the intended destination directory of the package when downloaded. Default is the session temporary directory given by `tempdir()`.}
+\item{pkg_path}{A character string describing the intended destination directory of the package when downloaded. Default is the session temporary directory given by \code{tempdir()}.}
 }
 \description{
 This function attempts to retrieve a Debian binary package corresponding

--- a/man/retrievePackage.Rd
+++ b/man/retrievePackage.Rd
@@ -4,17 +4,17 @@
 \alias{retrievePackage}
 \title{Retrieve an R package binary from Debian's package repository}
 \usage{
-retrievePackage(url, path = "/tmp")
+retrievePackage(url, path = tempdir())
 }
 \arguments{
 \item{url}{A character string which represents a valid URL to an R package.}
 
-\item{path}{A character string describing the path where the package should be downloaded. Defaults to /tmp.}
+\item{path}{A character string describing the path where the package should be downloaded. Defaults to \code{tempdir()}.}
 }
 \description{
 This function attempts to download an R package compiled for
 Debian (which may work on hosts running Ubuntu also) using
-curl to the directory specified in `path`.
+curl to the directory specified in \code{path}.
 }
 \keyword{Debian}
 \keyword{binary}

--- a/man/unpackPackage.Rd
+++ b/man/unpackPackage.Rd
@@ -4,19 +4,18 @@
 \alias{unpackPackage}
 \title{Extract a Debian archive containing an R package binary}
 \usage{
-unpackPackage(pkg_path, dest_path, clean = TRUE)
+unpackPackage(pkg_path, pkg_file, dest_path)
 }
 \arguments{
 \item{pkg_path}{A character string describing the location of the compressed package.}
 
-\item{dest_path}{A character string describing the intended destination directory of the package.}
+\item{pkg_file}{A character string describing the filename of the Debian package.}
 
-\item{clean}{Logical. A Boolean flag indicating whether the non-package directories extracted from the archive should be deleted.}
+\item{dest_path}{A character string describing the intended destination directory of the package.}
 }
 \description{
 This function uses `untar` to extract the R package from within a Debian
-archive, and, if `clean` is `TRUE`, deletes all non-package directories
-extracted from the archive.
+archive.
 }
 \keyword{Debian}
 \keyword{binary}

--- a/man/unpackPackage.Rd
+++ b/man/unpackPackage.Rd
@@ -4,7 +4,7 @@
 \alias{unpackPackage}
 \title{Extract a Debian archive containing an R package binary}
 \usage{
-unpackPackage(pkg_path, pkg_file, dest_path)
+unpackPackage(pkg_path = tempdir(), pkg_file, dest_path = tempdir())
 }
 \arguments{
 \item{pkg_path}{A character string describing the location of the compressed package.}
@@ -14,7 +14,7 @@ unpackPackage(pkg_path, pkg_file, dest_path)
 \item{dest_path}{A character string describing the intended destination directory of the package.}
 }
 \description{
-This function uses `untar` to extract the R package from within a Debian
+This function uses \code{untar} to extract the R package from within a Debian
 archive.
 }
 \keyword{Debian}


### PR DESCRIPTION
This PR proposes to add initial support for installing binary versions of packages when available from the Debian repository, and (optionally) fetching them from CRAN when they are not found.

It's far from ideal, but it's a start. Items requiring future attention:
- [ ] performance is a bit slower, primarily due to fetching sources/package information from Debian and CRAN; investigate caching/memoisation to reduce delays (totalling no more than 20-30 seconds in a session, which is still acceptable relative to compilation time)
- [ ] support for resolving versions is primitive, dependencies retrieved from CRAN are handled properly, but package binaries either retrieve the newest available or the version requested by the user; room for improvement
- [ ] tests are needed
- [ ] documentation could be improved
- [ ] code is somewhat messy, would benefit from refactoring

Closes #2.